### PR TITLE
Add verifier mappings for modded item / reforge item tags support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Tierify will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.0] - 2025-11-19
+## [1.3.0/1] - 2025-11-20
 
 ### Added
 - **Verifier Mappings System**: New data-driven system to extend item attribute verifiers to modded items without modifying base attribute files
@@ -21,16 +21,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **TagParsingHelper Utility Class**: Consolidated tag parsing and validation logic for better code maintainability
 
 ### Changed
+- **Improved logging output**: Reduced log verbosity by moving granular details to debug level
+  - Per-entry success messages now use `LOGGER.debug()` instead of `LOGGER.info()`
+  - Added summary statistics at info level (e.g., "Loaded 5 reforge definitions with 12 tags")
+  - Cleaner logs during normal operation while maintaining detailed debugging capability
 - Refactored `ReforgeDataLoader` to use centralized utility functions for tag parsing
 - Refactored `ItemVerifier` to use centralized utility functions for tag creation
 - Improved code organization and reduced duplication across data loaders
 
+### Fixed
+- **Fixed modded tag support**: Tags in `items` field now use lazy evaluation instead of load-time expansion
+  - Tags are stored as references and expanded at runtime when checking reforge eligibility
+  - This ensures modded tags (like `spartanweaponry:clubs`) work immediately without requiring `/reload`
+  - The `minecraft:tags` dependency ensures vanilla tags are available, but modded tags are checked dynamically
+  - Legacy system still supported for backward compatibility
+- **Improved tag loading reliability**: Reforge items and verifier mappings declare dependency on `minecraft:tags`
+  - Changed `ReforgeDataLoader` from `SimpleSynchronousResourceReloadListener` to `IdentifiableResourceReloadListener`
+  - Changed `VerifierMappingLoader` to implement `IdentifiableResourceReloadListener`
+  - Ensures vanilla tags are loaded before datapack processing begins
+- Fixed `ResourceLocationException` error when parsing tag references with `#` prefix
+- Fixed `NullPointerException` when JSON files are missing required fields:
+  - Added validation for required `base` and `items` fields in reforge_items JSON files
+  - Added validation for required `base_verifier`, `base_verifier_type`, and `mapped_verifiers` fields in verifier mapping files
+  - Added validation for `verifier` and `type` fields in mapped_verifiers array entries
+- Added proper error handling to prevent single malformed entries from breaking entire file loading
+- Skip registration of reforge data when no valid items or base materials are found
+- Skip registration of verifier mappings when no valid mapped verifiers exist
+
 ### Technical
-- Created `elocindev.tierify.util.TagParsingHelper` with methods for tag detection, extraction, creation, expansion, and item validation
-- Added `VerifierMapping` data class to represent verifier mappings
-- Added `VerifierMappingLoader` to load and manage verifier mapping files
-- Enhanced `ItemVerifier.isValid()` to check both direct matches and mapped verifiers
-- Added `ReforgeDataLoader.ReforgeBaseData` inner class to hold both direct items and tag references
+- **Lazy Tag Loading System**:
+  - Added `ReforgeDataLoader.ReforgeDefinition` class to store both direct items and tag references
+  - Tags in `items` field are now stored as `TagKey<Item>` references rather than expanded at load time
+  - Added `ReforgeDefinition.matchesItem()` method for runtime tag expansion
+  - Added `canReforge()` and `getReforgeDefinitionFor()` methods to check item eligibility
+  - Updated `ReforgeScreenHandler` to use lazy tag evaluation for runtime checks
+  - Legacy expansion system maintained for backward compatibility with existing code
+- **Utility Classes**:
+  - Created `elocindev.tierify.util.TagParsingHelper` with methods for tag detection, extraction, creation, expansion, and item validation
+  - Added `VerifierMapping` data class to represent verifier mappings
+  - Added `VerifierMappingLoader` to load and manage verifier mapping files
+- **Code Improvements**:
+  - Enhanced `ItemVerifier.isValid()` to check both direct matches and mapped verifiers
+  - Added `ReforgeDataLoader.ReforgeBaseData` inner class to hold both direct items and tag references for base materials
+  - Added validation in `TagParsingHelper` methods to prevent `#` prefix from being passed to `Identifier` constructor
+  - Wrapped individual entry parsing in try-catch blocks for graceful error recovery
+  - Added JSON field validation before processing reforge_items data
 
 ## [1.2.0] - Previous Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,48 @@
-# Tierify 1.2.0
-- Added sounds for reforging which change depending on the rarity. Thanks Sweeney!
+# Changelog
+
+All notable changes to Tierify will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.3.0] - 2025-11-19
+
+### Added
+- **Verifier Mappings System**: New data-driven system to extend item attribute verifiers to modded items without modifying base attribute files
+  - Add `data/<namespace>/verifier_mappings/*.json` files to map existing verifiers (like `c:swords`) to additional tags or items (like `c:halberds`)
+  - Automatically includes mapped items when checking tier eligibility
+  - See `VERIFIER_MAPPINGS.md` for full documentation
+- **Tag Support in Reforge Items**: Both `items` and `base` fields now support tag references using `#` prefix
+  - Use `"#c:swords"` to include all swords (vanilla + modded) in reforge recipes
+  - Use `"#c:ingots/iron"` to accept any iron ingot as base material
+  - Dramatically reduces file duplication - one entry can replace dozens of individual item entries
+  - Tag expansion happens at data load time with logging for debugging
+  - See `REFORGE_TAG_SUPPORT.md` for full documentation
+- **TagParsingHelper Utility Class**: Consolidated tag parsing and validation logic for better code maintainability
+
+### Changed
+- Refactored `ReforgeDataLoader` to use centralized utility functions for tag parsing
+- Refactored `ItemVerifier` to use centralized utility functions for tag creation
+- Improved code organization and reduced duplication across data loaders
+
+### Technical
+- Created `elocindev.tierify.util.TagParsingHelper` with methods for tag detection, extraction, creation, expansion, and item validation
+- Added `VerifierMapping` data class to represent verifier mappings
+- Added `VerifierMappingLoader` to load and manage verifier mapping files
+- Enhanced `ItemVerifier.isValid()` to check both direct matches and mapped verifiers
+- Added `ReforgeDataLoader.ReforgeBaseData` inner class to hold both direct items and tag references
+
+## [1.2.0] - Previous Release
+
+### Added
+- Added sounds for reforging which change depending on the rarity (Thanks Sweeney!)
+
+### Changed
 - Heavily toned down the negative effects of Common tier
 - Modifiers from tiers are now base multipliers instead of total
 - Removed negative effects from Rare tier
 - Removed health effects from armor high tiers
 - Limited speed effects from armor to 5% per piece
+
+### Fixed
 - Fixed tabs not being interchangeable when BCLib was installed

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Example:
 Reforging items to get other tiers can be done at the anvil. There is a slot which is called "base" on the left and a slot called "addition" on the right.
 The addition slot can only contain items which are stated in each tier item tag (`tiered:reforge_tier_1`, `tiered:reforge_tier_2`, `tiered:reforge_tier_3`). The base slot can contain the reforging item material item if existent, otherwise it can only contain `tiered:reforge_base_item` tag items. The base slot item can get changed via datapack, an example can be found below and has to get put in the `tiered:reforge_items` folder.
 
+**NEW: Tag Support** - The `base` field now supports tags! Prefix tag identifiers with `#` to accept any items in that tag. See **[REFORGE_TAG_SUPPORT.md](REFORGE_TAG_SUPPORT.md)** for full documentation.
+
 ```json
 {
   "items": [
@@ -153,6 +155,19 @@ The addition slot can only contain items which are stated in each tier item tag 
   ],
   "base": [
     "minecraft:string"
+  ]
+}
+```
+
+Example using tags:
+```json
+{
+  "items": [
+    "minecraft:iron_sword",
+    "minecraft:iron_axe"
+  ],
+  "base": [
+    "#c:ingots/iron"
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -252,8 +252,16 @@ See [Fabric Convention Tags](https://github.com/FabricMC/fabric/tree/1.20.1/fabr
 
 **Reforge not working with modded items?**
 - Use tag-based reforge recipes with `#` prefix
-- Verify the tag exists and contains your items
-- Check logs after `/reload` for "Expanded tag X to Y items" messages
+- Verify the tag exists using `/tag list items <modid>`
+- Check logs for "Expanded tag X to Y items" messages
+- If tag expands to 0 items, the tag likely doesn't exist or is empty
+
+**Tag expanded to 0 items warning?**
+- **In v1.3.0+**: This warning is informational for the legacy system only
+- Tags in the `items` field now use **lazy evaluation** - they're checked at runtime, not load time
+- Modded tags will work correctly even if the warning appears during load
+- The warning only appears for the backward compatibility system
+- **If reforge still doesn't work**: Verify the tag actually exists with `/tag list items <modid>`
 
 **Changes not taking effect?**
 - Run `/reload` command in-game to reload datapacks

--- a/README.md
+++ b/README.md
@@ -28,6 +28,34 @@ Tierify expands upon Tiered by changing various things, but keeps its mod id and
 ### Installation
 Tierify is a mod built for the [Fabric Loader](https://fabricmc.net/). It requires [Fabric API](https://www.curseforge.com/minecraft/mc-mods/fabric-api) & [Necronomicon API](https://www.curseforge.com/minecraft/mc-mods/necronomicon) (and [Synitra Connector](https://www.curseforge.com/minecraft/mc-mods/sinytra-connector) if on Forge/NeoForge) to be installed separately; all other dependencies are included inside the mod.
 
+### Quick Start: Adding Modded Item Support
+
+**Problem**: Modded weapons/tools/armor not receiving tiers?
+
+**Solution 1 - Verifier Mappings** (Recommended for adding tiers to items):
+Create `data/tiered/verifier_mappings/my_mod_support.json`:
+```json
+{
+  "base_verifier": "c:swords",
+  "mapped_verifiers": [
+    {"verifier": "c:halberds", "type": "tag"},
+    {"verifier": "c:spears", "type": "tag"}
+  ]
+}
+```
+Now halberds and spears will receive the same tiers as swords! See [VERIFIER_MAPPINGS.md](VERIFIER_MAPPINGS.md) for details.
+
+**Solution 2 - Reforge Tag Support** (Recommended for reforging recipes):
+Create `data/tiered/reforge_items/all_modded_weapons.json`:
+```json
+{
+  "items": ["#c:swords", "#c:axes"],
+  "base": ["#c:ingots/iron"]
+}
+```
+All swords and axes (vanilla + modded) can now be reforged with iron ingots! See [REFORGE_TAG_SUPPORT.md](REFORGE_TAG_SUPPORT.md) for details.
+*This would not typically be recommended for a multi-material tag like `"#c:swords"` but can be useful for modded support such as Spartan Weaponry where the tag `"#spartanweaponry:aluminum_weapons"` would contain items which all utilise aluminum as a base material.*
+
 ### Customization
 
 Tierify is entirely data-driven, which means you can add, modify, and remove modifiers as you see fit. The base path for modifiers is `data/modid/item_attributes`, and tiered modifiers are stored under the modid of tiered.
@@ -41,7 +69,9 @@ For example, to make all Spartan Weaponry halberds receive the same tiers as swo
 
 See **[VERIFIER_MAPPINGS.md](VERIFIER_MAPPINGS.md)** for full documentation.
 
-Here's an example modifier called "Hasteful," which grants additional dig speed when any of the valid tools are held:
+### Example: Hasteful modifier
+
+A simple modifier example that grants +10% dig speed when a valid tool (pickaxe, shovel, or axe) is held in the main hand. Save this JSON as a modifier file (for example: `data/your_datapack/item_attributes/tiered/hasteful.json`). The modifier uses verifiers to target tool tags, a weight of 10, and applies a MULTIPLY_BASE dig speed modifier when equipped in the MAINHAND.
 ```json
 {
   "id": "tiered:hasteful",
@@ -146,8 +176,9 @@ Example:
 Reforging items to get other tiers can be done at the anvil. There is a slot which is called "base" on the left and a slot called "addition" on the right.
 The addition slot can only contain items which are stated in each tier item tag (`tiered:reforge_tier_1`, `tiered:reforge_tier_2`, `tiered:reforge_tier_3`). The base slot can contain the reforging item material item if existent, otherwise it can only contain `tiered:reforge_base_item` tag items. The base slot item can get changed via datapack, an example can be found below and has to get put in the `tiered:reforge_items` folder.
 
-**NEW: Tag Support** - The `base` field now supports tags! Prefix tag identifiers with `#` to accept any items in that tag. See **[REFORGE_TAG_SUPPORT.md](REFORGE_TAG_SUPPORT.md)** for full documentation.
+**NEW: Tag Support** - Both the `items` and `base` fields now support tags! Prefix tag identifiers with `#` to use tags instead of listing individual items. This dramatically reduces file duplication and automatically supports modded items. See **[REFORGE_TAG_SUPPORT.md](REFORGE_TAG_SUPPORT.md)** for full documentation.
 
+Basic example (direct items):
 ```json
 {
   "items": [
@@ -159,7 +190,7 @@ The addition slot can only contain items which are stated in each tier item tag 
 }
 ```
 
-Example using tags:
+Example using tags in `base` field:
 ```json
 {
   "items": [
@@ -171,6 +202,63 @@ Example using tags:
   ]
 }
 ```
+
+Example using tags in both `items` and `base` fields (recommended for broad coverage):
+```json
+{
+  "items": [
+    "#c:swords"
+  ],
+  "base": [
+    "#c:ingots/iron"
+  ]
+}
+```
+
+This single entry creates reforge recipes for **all swords** (vanilla + modded) using **any iron ingot** (vanilla + modded).
+
+### Common Tags Reference
+
+When creating verifier mappings or reforge recipes, these common convention tags are available:
+
+**Weapons & Tools:**
+- `c:swords` - All swords
+- `c:axes` - All axes  
+- `c:pickaxes` - All pickaxes
+- `c:shovels` - All shovels
+- `c:hoes` - All hoes
+- `c:tools` - All tools
+
+**Armor:**
+- `c:helmets` - All helmets
+- `c:chestplates` - All chestplates
+- `c:leggings` - All leggings
+- `c:boots` - All boots
+- `c:armor` - All armor pieces
+
+**Materials:**
+- `c:ingots/iron`, `c:ingots/gold`, `c:ingots/copper` - Metal ingots
+- `c:gems/diamond`, `c:gems/emerald` - Gems
+- `minecraft:planks`, `minecraft:logs` - Wood materials
+
+See [Fabric Convention Tags](https://github.com/FabricMC/fabric/tree/1.20.1/fabric-convention-tags-v1) for complete list.
+
+### Troubleshooting
+
+**Modded items not getting tiers?**
+- Check if the mod uses convention tags (most do)
+- Create a verifier mapping to extend existing verifiers to the mod's tags
+- Check logs for "Resource was not loaded" messages indicating invalid item IDs
+
+**Reforge not working with modded items?**
+- Use tag-based reforge recipes with `#` prefix
+- Verify the tag exists and contains your items
+- Check logs after `/reload` for "Expanded tag X to Y items" messages
+
+**Changes not taking effect?**
+- Run `/reload` command in-game to reload datapacks
+- Check for JSON syntax errors in your datapack files
+- Enable debug logging to see detailed information
 
 ### Credits
 - **Draylar1** for making **Tiered**, the original mod.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,18 @@ Tierify is a mod built for the [Fabric Loader](https://fabricmc.net/). It requir
 
 ### Customization
 
-Tierify is entirely data-driven, which means you can add, modify, and remove modifiers as you see fit. The base path for modifiers is `data/modid/item_attributes`, and tiered modifiers are stored under the modid of tiered. Here's an example modifier called "Hasteful," which grants additional dig speed when any of the valid tools are held:
+Tierify is entirely data-driven, which means you can add, modify, and remove modifiers as you see fit. The base path for modifiers is `data/modid/item_attributes`, and tiered modifiers are stored under the modid of tiered.
+
+#### **NEW: Verifier Mappings for Modded Item Support**
+
+Tierify now supports **verifier mappings** which allow you to extend existing attribute verifiers to work with modded items **without modifying any attribute files**. This is the recommended way to add support for modded weapons, tools, and armor.
+
+For example, to make all Spartan Weaponry halberds receive the same tiers as swords, create:  
+`data/tiered/verifier_mappings/spartanweaponry.json`
+
+See **[VERIFIER_MAPPINGS.md](VERIFIER_MAPPINGS.md)** for full documentation.
+
+Here's an example modifier called "Hasteful," which grants additional dig speed when any of the valid tools are held:
 ```json
 {
   "id": "tiered:hasteful",

--- a/REFORGE_TAG_SUPPORT.md
+++ b/REFORGE_TAG_SUPPORT.md
@@ -1,15 +1,15 @@
 # Reforge Item Tag Support
 
-Starting with this version, Tierify supports using **tags** in the `base` field of reforge item definitions. This allows for more flexible and cross-mod compatible reforge material specifications.
+Starting with this version, Tierify supports using **tags** in both the `base` and `items` fields of reforge item definitions. This allows for more flexible and cross-mod compatible reforge specifications with significantly reduced duplication.
 
 ## How It Works
 
-In your `data/<namespace>/reforge_items/*.json` files, you can now use tags by prefixing them with `#`:
+In your `data/<namespace>/reforge_items/*.json` files, you can now use tags in both fields by prefixing them with `#`:
 
 ```json
 {
   "items": [
-    "minecraft:iron_sword"
+    "#c:swords"
   ],
   "base": [
     "#c:ingots/iron"
@@ -17,23 +17,25 @@ In your `data/<namespace>/reforge_items/*.json` files, you can now use tags by p
 }
 ```
 
+When using tags in the `items` field, the system automatically expands the tag to include all items in that tag, creating reforge entries for each one.
+
 ## Syntax
 
-### Using Tags
+### Base Field - Using Tags for Materials
 
-Prefix tag identifiers with `#`:
+Prefix tag identifiers with `#` to match any material in that tag:
 ```json
 "base": ["#c:ingots/iron"]
 ```
 
-### Using Direct Item IDs
+### Base Field - Using Direct Item IDs
 
 No prefix needed (backward compatible):
 ```json
 "base": ["minecraft:iron_ingot"]
 ```
 
-### Mixing Both
+### Base Field - Mixing Both
 
 You can combine tags and direct item IDs:
 ```json
@@ -48,9 +50,58 @@ You can combine tags and direct item IDs:
 
 This accepts either any item in the `c:gems/diamond` tag **OR** the direct `minecraft:diamond` item.
 
+### Items Field - Using Tags for Tools/Items
+
+Prefix tag identifiers with `#` to automatically create reforge entries for all items in that tag:
+```json
+"items": ["#c:swords"]
+```
+
+This automatically expands to all items tagged with `c:swords` (vanilla swords, modded swords, etc.).
+
+### Items Field - Using Direct Item IDs
+
+No prefix needed (backward compatible):
+```json
+"items": ["minecraft:iron_sword"]
+```
+
+### Items Field - Mixing Both
+
+You can combine tags and direct item IDs:
+```json
+{
+  "items": [
+    "#c:swords",
+    "minecraft:trident",
+    "custom_mod:special_weapon"
+  ],
+  "base": ["#c:ingots/iron"]
+}
+```
+
+This creates reforge entries for all swords (via tag) PLUS the trident and special weapon (direct IDs).
+
 ## Examples
 
-### Example 1: Iron Tools Using Tag
+### Example 1: All Swords with Iron (Tag Expansion)
+
+```json
+{
+  "items": [
+    "#c:swords"
+  ],
+  "base": [
+    "#c:ingots/iron"
+  ]
+}
+```
+
+**Result:** Creates reforge entries for **every** sword (vanilla + modded) that uses iron ingots as the base material. This single entry replaces dozens of individual entries.
+
+**Items expanded:** `minecraft:wooden_sword`, `minecraft:stone_sword`, `minecraft:iron_sword`, `minecraft:golden_sword`, `minecraft:diamond_sword`, `minecraft:netherite_sword`, plus any modded swords tagged with `c:swords`.
+
+### Example 2: Iron Tools Using Base Tag (Backward Compatible)
 
 ```json
 {
@@ -65,11 +116,11 @@ This accepts either any item in the `c:gems/diamond` tag **OR** the direct `mine
 }
 ```
 
-**Result:** Any item tagged with `c:ingots/iron` can be used to reforge these tools. This includes:
+**Result:** Any item tagged with `c:ingots/iron` can be used to reforge these specific tools. This includes:
 - `minecraft:iron_ingot`
 - Any modded iron ingots that are properly tagged
 
-### Example 2: Gold Items Using Convention Tags
+### Example 3: Gold Items Using Convention Tags
 
 ```json
 {
@@ -84,26 +135,29 @@ This accepts either any item in the `c:gems/diamond` tag **OR** the direct `mine
 }
 ```
 
-### Example 3: Mixed Direct Items and Tags
+### Example 4: Mixed Tags and Direct Items
 
 ```json
 {
-  "items": ["minecraft:netherite_sword"],
+  "items": [
+    "#c:swords",
+    "#c:axes",
+    "minecraft:trident"
+  ],
   "base": [
     "#c:ingots/netherite",
-    "minecraft:netherite_ingot",
     "minecraft:netherite_scrap"
   ]
 }
 ```
 
-**Result:** Accepts netherite ingots (via tag OR direct ID) AND netherite scraps.
+**Result:** All swords and axes (via tags) PLUS the trident can be reforged using netherite ingots (via tag) OR netherite scraps (direct ID).
 
-### Example 4: Multiple Tag Types
+### Example 5: Multiple Tag Types for Base Materials
 
 ```json
 {
-  "items": ["minecraft:wooden_sword"],
+  "items": ["#minecraft:wooden_items"],
   "base": [
     "#minecraft:planks",
     "#minecraft:logs"
@@ -111,7 +165,7 @@ This accepts either any item in the `c:gems/diamond` tag **OR** the direct `mine
 }
 ```
 
-**Result:** Any planks OR logs can be used to reforge wooden swords.
+**Result:** All wooden items can be reforged using any planks OR logs.
 
 ## Common Tag Conventions
 
@@ -132,12 +186,56 @@ The [Common Convention Tags](https://github.com/FabricMC/fabric/blob/1.20.1/fabr
 
 ## Benefits
 
-### 1. Cross-Mod Compatibility
+### 1. Dramatic Reduction in File Duplication
+
+Using tags in the `items` field eliminates the need for separate entries for each item:
+
+**Before (dozens of entries needed):**
+```json
+// File 1: wooden_sword.json
+{"items": ["minecraft:wooden_sword"], "base": ["#minecraft:planks"]}
+
+// File 2: stone_sword.json
+{"items": ["minecraft:stone_sword"], "base": ["#minecraft:stone_tool_materials"]}
+
+// File 3: iron_sword.json
+{"items": ["minecraft:iron_sword"], "base": ["#c:ingots/iron"]}
+
+// ... dozens more files for each sword type ...
+```
+
+**After (single entry):**
+```json
+// File: all_swords.json
+{"items": ["#c:swords"], "base": ["#c:ingots/iron"]}
+```
+
+### 2. Automatic Modded Item Support
+
+When using tags in the `items` field, newly added modded items are automatically included:
+
+```json
+{
+  "items": ["#c:swords"],
+  "base": ["#c:ingots/steel"]
+}
+```
+
+This automatically includes:
+- All vanilla swords
+- Spartan Weaponry swords
+- Simply Swords content
+- Any future mod's swords (if properly tagged)
+
+**No file updates needed** when adding new mods!
+
+### 3. Cross-Mod Material Compatibility
+
 Works with any mod that adds materials using conventional tags:
 
 ```json
 {
-  "items": ["custom_mod:steel_sword"],
+  "items": ["#c:tools"],
   "base": ["#c:ingots/steel"]
 }
 ```
@@ -148,25 +246,24 @@ This works with:
 - Tech Reborn steel
 - Any other mod's steel (if properly tagged)
 
-### 2. Reduced File Duplication
-Instead of creating separate files for each material variant:
+### 4. Simplified Maintenance
 
-**Before (multiple files needed):**
+Instead of maintaining hundreds of individual entries, you can manage a handful of tag-based rules:
+
 ```json
-// File 1: iron_tools_forge.json
-{"items": [...], "base": ["minecraft:iron_ingot"]}
+// One entry covers all swords from all mods
+{"items": ["#c:swords"], "base": ["#c:ingots/iron"]}
 
-// File 2: iron_tools_create.json  
-{"items": [...], "base": ["create:iron_sheet"]}
+// One entry covers all axes from all mods  
+{"items": ["#c:axes"], "base": ["#c:ingots/iron"]}
+
+// One entry covers all pickaxes from all mods
+{"items": ["#c:pickaxes"], "base": ["#c:ingots/iron"]}
 ```
 
-**After (single file):**
-```json
-{"items": [...], "base": ["#c:ingots/iron"]}
-```
+### 5. Future-Proof
 
-### 3. Future-Proof
-New mods that add materials will automatically work if they use standard tags.
+New mods that add items will automatically work if they use standard tags. No datapack updates required.
 
 ## Backward Compatibility
 
@@ -191,15 +288,46 @@ To find available tags in your modpack:
 
 ## Technical Details
 
-### Tag Resolution
-- Tags are resolved at runtime when checking reforge validity
+### Tag Expansion in Items Field
+
+When tags are used in the `items` field, the system performs **expansion at data load time**:
+
+1. **Parse Phase**: Reads `"#c:swords"` from JSON
+2. **Expansion Phase**: Iterates through all registered items
+3. **Matching Phase**: Checks if each item has the tag using `isIn(tag)`
+4. **Registration Phase**: Creates individual reforge entries for each matched item
+
+Example log output:
+```
+[Tierify] Expanded tag c:swords to 12 items for reforge
+```
+
+This means the single `"#c:swords"` entry became 12 individual reforge entries (one per sword).
+
+**Important:** Tag expansion happens during world load/resource reload, not during gameplay. This means:
+- ✅ No performance impact during reforging
+- ✅ Changes require `/reload` command to take effect
+- ⚠️ Items added by mods after load won't be included until next reload
+
+### Tag Resolution in Base Field
+
+Tags in the `base` field work differently - they're resolved **at runtime** when checking reforge validity:
+
+- Tags are evaluated when items are placed in the reforge interface
 - If a tag doesn't exist, it's treated as empty (no items match)
 - No errors or crashes occur with non-existent tags
 
 ### Performance
+
+#### Items Field Tags
+- Expansion happens once during resource load
+- Zero runtime overhead - works exactly like direct item IDs afterward
+- May increase initial load time slightly with very large tag sets
+
+#### Base Field Tags  
 - Tag checks are cached by Minecraft's tag system
 - Minimal performance impact compared to direct item checks
-- Tags are only evaluated when items are placed in the reforge interface
+- Only evaluated when items are placed in the reforge interface
 
 ### Priority
 When multiple base options exist, ANY match is valid:
@@ -212,33 +340,70 @@ Either iron ingots (any) OR copper ingot will work.
 
 ### Migrating Existing Files
 
-**Old format:**
+**Old format (many individual files):**
 ```json
-{
-  "items": ["minecraft:iron_sword"],
-  "base": ["minecraft:iron_ingot"]
-}
+// File 1: wooden_sword.json
+{"items": ["minecraft:wooden_sword"], "base": ["minecraft:stick"]}
+
+// File 2: stone_sword.json
+{"items": ["minecraft:stone_sword"], "base": ["minecraft:cobblestone"]}
+
+// File 3: iron_sword.json
+{"items": ["minecraft:iron_sword"], "base": ["minecraft:iron_ingot"]}
+
+// ... dozens more ...
 ```
 
-**New format (recommended):**
+**New format (single file with tags):**
 ```json
+// File: all_swords.json
 {
-  "items": ["minecraft:iron_sword"],
+  "items": ["#c:swords"],
   "base": ["#c:ingots/iron"]
 }
 ```
 
 ### When to Use Tags vs Direct Items
 
-**Use tags when:**
+#### Use Tags in `items` Field When:
+- ✅ Want to apply reforge to all items of a type (all swords, all pickaxes)
+- ✅ Want automatic support for modded items
+- ✅ Items are grouped in standard tags (c:swords, c:axes, etc.)
+- ✅ Want to reduce file count dramatically
+
+#### Use Direct Items in `items` Field When:
+- ✅ Need specific control over individual items
+- ✅ Item requires unique base materials
+- ✅ Creating exceptions to tag-based rules
+
+#### Use Tags in `base` Field When:
 - ✅ Material has cross-mod equivalents (iron, gold, copper)
 - ✅ Want to support modded variants automatically
 - ✅ Material is part of convention tags
 
-**Use direct items when:**
+#### Use Direct Items in `base` Field When:
 - ✅ Item is unique to one mod
 - ✅ No standard tag exists
-- ✅ Need precise control over accepted items
+- ✅ Need precise control over accepted materials
+
+### Recommended Strategy
+
+**Start with broad tag-based rules:**
+```json
+// Cover 90% of items with a few files
+{"items": ["#c:swords"], "base": ["#c:ingots/iron"]}
+{"items": ["#c:axes"], "base": ["#c:ingots/iron"]}
+{"items": ["#c:pickaxes"], "base": ["#c:ingots/iron"]}
+```
+
+**Add specific exceptions as needed:**
+```json
+// Special case for unique items
+{
+  "items": ["minecraft:trident"],
+  "base": ["minecraft:prismarine_shard", "minecraft:prismarine_crystals"]
+}
+```
 
 ## Troubleshooting
 
@@ -260,16 +425,35 @@ Either iron ingots (any) OR copper ingot will work.
 ## Examples in This Mod
 
 See the following example files:
-- `data/tiered/reforge_items/iron_tools.json` - Uses `#c:ingots/iron`
+- `data/tiered/reforge_items/all_swords.json` - Uses `#c:swords` in items field for all swords
+- `data/tiered/reforge_items/all_tools.json` - Uses multiple tags in items field (`#c:pickaxes`, `#c:axes`, `#c:hoes`)
+- `data/tiered/reforge_items/iron_tools.json` - Uses `#c:ingots/iron` in base field
 - `data/tiered/reforge_items/diamond_tools.json` - Mixes tags and direct items
 - `data/tiered/reforge_items/elytra.json` - Direct item (no tag)
 
 ## Best Practices
 
-1. **Use convention tags** (`c:`) when available for maximum compatibility
-2. **Mix formats** when needed - tags for common materials, direct items for unique ones
-3. **Document custom tags** if creating new ones for your modpack
-4. **Test thoroughly** with your modpack's installed mods
+1. **Prefer tags in items field** for item categories - drastically reduces file count
+   - `{"items": ["#c:swords"]}` instead of listing every sword
+   
+2. **Use convention tags** (`c:`) when available for maximum compatibility
+   - `#c:swords`, `#c:axes`, `#c:pickaxes` for tools
+   - `#c:ingots/iron`, `#c:gems/diamond` for materials
+
+3. **Mix formats strategically**
+   - Tags for broad categories: `"items": ["#c:swords"]`
+   - Direct items for exceptions: `"items": ["minecraft:trident"]`
+   - Both together when needed: `"items": ["#c:swords", "minecraft:trident"]`
+
+4. **Start broad, add specifics**
+   - Create general tag-based rules first
+   - Add specific entries for unique items with special requirements
+
+5. **Document custom tags** if creating new ones for your modpack
+
+6. **Test thoroughly** with your modpack's installed mods
+   - Verify tag expansion works (check logs for "Expanded tag X to Y items")
+   - Test reforge interface with modded items
 
 ## Related Documentation
 

--- a/REFORGE_TAG_SUPPORT.md
+++ b/REFORGE_TAG_SUPPORT.md
@@ -1,0 +1,277 @@
+# Reforge Item Tag Support
+
+Starting with this version, Tierify supports using **tags** in the `base` field of reforge item definitions. This allows for more flexible and cross-mod compatible reforge material specifications.
+
+## How It Works
+
+In your `data/<namespace>/reforge_items/*.json` files, you can now use tags by prefixing them with `#`:
+
+```json
+{
+  "items": [
+    "minecraft:iron_sword"
+  ],
+  "base": [
+    "#c:ingots/iron"
+  ]
+}
+```
+
+## Syntax
+
+### Using Tags
+
+Prefix tag identifiers with `#`:
+```json
+"base": ["#c:ingots/iron"]
+```
+
+### Using Direct Item IDs
+
+No prefix needed (backward compatible):
+```json
+"base": ["minecraft:iron_ingot"]
+```
+
+### Mixing Both
+
+You can combine tags and direct item IDs:
+```json
+{
+  "items": ["minecraft:diamond_sword"],
+  "base": [
+    "#c:gems/diamond",
+    "minecraft:diamond"
+  ]
+}
+```
+
+This accepts either any item in the `c:gems/diamond` tag **OR** the direct `minecraft:diamond` item.
+
+## Examples
+
+### Example 1: Iron Tools Using Tag
+
+```json
+{
+  "items": [
+    "minecraft:iron_sword",
+    "minecraft:iron_axe",
+    "minecraft:iron_pickaxe"
+  ],
+  "base": [
+    "#c:ingots/iron"
+  ]
+}
+```
+
+**Result:** Any item tagged with `c:ingots/iron` can be used to reforge these tools. This includes:
+- `minecraft:iron_ingot`
+- Any modded iron ingots that are properly tagged
+
+### Example 2: Gold Items Using Convention Tags
+
+```json
+{
+  "items": [
+    "minecraft:golden_sword",
+    "minecraft:golden_pickaxe",
+    "minecraft:golden_axe"
+  ],
+  "base": [
+    "#c:ingots/gold"
+  ]
+}
+```
+
+### Example 3: Mixed Direct Items and Tags
+
+```json
+{
+  "items": ["minecraft:netherite_sword"],
+  "base": [
+    "#c:ingots/netherite",
+    "minecraft:netherite_ingot",
+    "minecraft:netherite_scrap"
+  ]
+}
+```
+
+**Result:** Accepts netherite ingots (via tag OR direct ID) AND netherite scraps.
+
+### Example 4: Multiple Tag Types
+
+```json
+{
+  "items": ["minecraft:wooden_sword"],
+  "base": [
+    "#minecraft:planks",
+    "#minecraft:logs"
+  ]
+}
+```
+
+**Result:** Any planks OR logs can be used to reforge wooden swords.
+
+## Common Tag Conventions
+
+The [Common Convention Tags](https://github.com/FabricMC/fabric/blob/1.20.1/fabric-convention-tags-v1/src/main/resources/data/c/tags/items/) provide standardized tags:
+
+### Material Tags
+- `#c:ingots/iron` - Iron ingots
+- `#c:ingots/gold` - Gold ingots
+- `#c:ingots/copper` - Copper ingots
+- `#c:gems/diamond` - Diamonds
+- `#c:gems/emerald` - Emeralds
+- `#c:dusts/redstone` - Redstone dust
+
+### Block Type Tags
+- `#minecraft:planks` - All wooden planks
+- `#minecraft:logs` - All logs
+- `#minecraft:stone_tool_materials` - Cobblestone, blackstone, etc.
+
+## Benefits
+
+### 1. Cross-Mod Compatibility
+Works with any mod that adds materials using conventional tags:
+
+```json
+{
+  "items": ["custom_mod:steel_sword"],
+  "base": ["#c:ingots/steel"]
+}
+```
+
+This works with:
+- Create's steel ingots
+- Immersive Engineering steel
+- Tech Reborn steel
+- Any other mod's steel (if properly tagged)
+
+### 2. Reduced File Duplication
+Instead of creating separate files for each material variant:
+
+**Before (multiple files needed):**
+```json
+// File 1: iron_tools_forge.json
+{"items": [...], "base": ["minecraft:iron_ingot"]}
+
+// File 2: iron_tools_create.json  
+{"items": [...], "base": ["create:iron_sheet"]}
+```
+
+**After (single file):**
+```json
+{"items": [...], "base": ["#c:ingots/iron"]}
+```
+
+### 3. Future-Proof
+New mods that add materials will automatically work if they use standard tags.
+
+## Backward Compatibility
+
+✅ **Fully backward compatible** - existing reforge files without `#` continue to work exactly as before.
+
+Old format still works:
+```json
+{
+  "items": ["minecraft:iron_sword"],
+  "base": ["minecraft:iron_ingot"]
+}
+```
+
+## Tag Discovery
+
+To find available tags in your modpack:
+
+1. **In-game**: Use commands like `/tag list items` (requires permissions)
+2. **Datapacks**: Look in `data/c/tags/items/` folders
+3. **Mod sources**: Check mod GitHub repositories for tag definitions
+4. **Convention tags**: See [Fabric Convention Tags](https://github.com/FabricMC/fabric/tree/1.20.1/fabric-convention-tags-v1/src/main/resources/data/c/tags/items)
+
+## Technical Details
+
+### Tag Resolution
+- Tags are resolved at runtime when checking reforge validity
+- If a tag doesn't exist, it's treated as empty (no items match)
+- No errors or crashes occur with non-existent tags
+
+### Performance
+- Tag checks are cached by Minecraft's tag system
+- Minimal performance impact compared to direct item checks
+- Tags are only evaluated when items are placed in the reforge interface
+
+### Priority
+When multiple base options exist, ANY match is valid:
+```json
+"base": ["#c:ingots/iron", "minecraft:copper_ingot"]
+```
+Either iron ingots (any) OR copper ingot will work.
+
+## Migration Guide
+
+### Migrating Existing Files
+
+**Old format:**
+```json
+{
+  "items": ["minecraft:iron_sword"],
+  "base": ["minecraft:iron_ingot"]
+}
+```
+
+**New format (recommended):**
+```json
+{
+  "items": ["minecraft:iron_sword"],
+  "base": ["#c:ingots/iron"]
+}
+```
+
+### When to Use Tags vs Direct Items
+
+**Use tags when:**
+- ✅ Material has cross-mod equivalents (iron, gold, copper)
+- ✅ Want to support modded variants automatically
+- ✅ Material is part of convention tags
+
+**Use direct items when:**
+- ✅ Item is unique to one mod
+- ✅ No standard tag exists
+- ✅ Need precise control over accepted items
+
+## Troubleshooting
+
+### Tag not working in-game?
+
+**Check:**
+1. Is the tag name correct? (Check for typos)
+2. Does the tag exist? (Use `/tag list items`)
+3. Are items properly tagged? (Mods must register their items to tags)
+4. Is the `#` prefix included?
+
+### Items not being accepted?
+
+**Verify:**
+1. Tag syntax: `"#c:ingots/iron"` (with quotes and #)
+2. Tag namespace: Include namespace (e.g., `c:` or `minecraft:`)
+3. Tag actually contains items: Some tags may be empty without certain mods
+
+## Examples in This Mod
+
+See the following example files:
+- `data/tiered/reforge_items/iron_tools.json` - Uses `#c:ingots/iron`
+- `data/tiered/reforge_items/diamond_tools.json` - Mixes tags and direct items
+- `data/tiered/reforge_items/elytra.json` - Direct item (no tag)
+
+## Best Practices
+
+1. **Use convention tags** (`c:`) when available for maximum compatibility
+2. **Mix formats** when needed - tags for common materials, direct items for unique ones
+3. **Document custom tags** if creating new ones for your modpack
+4. **Test thoroughly** with your modpack's installed mods
+
+## Related Documentation
+
+- [Verifier Mappings](VERIFIER_MAPPINGS.md) - For extending which items can receive tiers
+- [README.md](README.md) - General customization documentation

--- a/VERIFIER_MAPPINGS.md
+++ b/VERIFIER_MAPPINGS.md
@@ -1,0 +1,202 @@
+# Verifier Mappings
+
+Verifier mappings allow you to extend existing item attribute verifiers (like `c:swords`) to also match additional tags or specific item IDs **without modifying the base attribute files**.
+
+This is especially useful for adding support for modded items that don't fit into conventional tags.
+
+## How It Works
+
+When Tierify checks if an item should receive a tier, it:
+1. First checks the direct verifier (e.g., is the item in `c:swords`?)
+2. Then checks any mapped verifiers you've defined (e.g., is it in `c:halberds`? or is it `spartanweaponry:wooden_halberd`?)
+
+If either check passes, the item is eligible for that tier.
+
+## File Location
+
+Verifier mapping files go in: `data/<namespace>/verifier_mappings/*.json`
+
+For example:
+- `data/tiered/verifier_mappings/spartanweaponry_melee.json`
+
+## File Format
+
+```json
+{
+  "base_verifier": "c:swords",
+  "base_verifier_type": "tag",
+  "mapped_verifiers": [
+    {
+      "verifier": "c:halberds",
+      "type": "tag"
+    },
+    {
+      "verifier": "spartanweaponry:wooden_halberd",
+      "type": "id"
+    }
+  ]
+}
+```
+
+### Fields:
+
+- **`base_verifier`** (string, required): The original verifier to extend (e.g., `"c:swords"`, `"minecraft:diamond_sword"`)
+- **`base_verifier_type`** (string, required): Either `"tag"` or `"id"`
+- **`mapped_verifiers`** (array, required): List of additional verifiers to check
+  - **`verifier`** (string, required): The tag or item ID to add
+  - **`type`** (string, required): Either `"tag"` or `"id"`
+
+## Examples
+
+### Example 1: Map Modded Weapon Tags to Existing Sword Attributes
+
+This makes all polearms, halberds, and spears eligible for the same attributes as swords:
+
+```json
+{
+  "base_verifier": "c:swords",
+  "base_verifier_type": "tag",
+  "mapped_verifiers": [
+    {
+      "verifier": "c:polearms",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:halberds",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:spears",
+      "type": "tag"
+    }
+  ]
+}
+```
+
+### Example 2: Add Specific Items by ID
+
+For items that don't have conventional tags:
+
+```json
+{
+  "base_verifier": "c:swords",
+  "base_verifier_type": "tag",
+  "mapped_verifiers": [
+    {
+      "verifier": "spartanweaponry:wooden_halberd",
+      "type": "id"
+    },
+    {
+      "verifier": "spartanweaponry:iron_halberd",
+      "type": "id"
+    },
+    {
+      "verifier": "spartanweaponry:diamond_halberd",
+      "type": "id"
+    }
+  ]
+}
+```
+
+### Example 3: Map Ranged Weapons
+
+Extend bow attributes to cover crossbows and javelins:
+
+```json
+{
+  "base_verifier": "c:bows",
+  "base_verifier_type": "tag",
+  "mapped_verifiers": [
+    {
+      "verifier": "c:crossbows",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:javelins",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:throwing_knives",
+      "type": "tag"
+    }
+  ]
+}
+```
+
+### Example 4: Map Specific Item ID to Another Item ID
+
+Extend a specific item's attributes to another item:
+
+```json
+{
+  "base_verifier": "minecraft:diamond_sword",
+  "base_verifier_type": "id",
+  "mapped_verifiers": [
+    {
+      "verifier": "betterend:aeternium_sword",
+      "type": "id"
+    }
+  ]
+}
+```
+
+## Multiple Mappings
+
+You can create multiple mapping files for the same base verifier. They will be **merged automatically**.
+
+For example:
+- `spartanweaponry_melee.json` maps `c:swords` to `c:halberds`, `c:polearms`
+- `additional_weapons.json` also maps `c:swords` to `c:katanas`, `c:rapiers`
+
+Result: `c:swords` will match all of: swords, halberds, polearms, katanas, and rapiers.
+
+## Use Cases
+
+1. **Supporting Modded Weapons**: Add Spartan Weaponry halberds, Simply Swords katanas, etc.
+2. **Cross-Mod Compatibility**: Make weapons from different mods share attribute pools
+3. **Custom Weapon Categories**: Group unconventional weapons together
+4. **Quick Fixes**: Add support for specific items without editing attribute files
+
+## What Gets Mapped?
+
+Verifier mappings affect **ALL attributes** that use the base verifier. For example:
+
+If you map `c:halberds` to `c:swords`, then:
+- All common sword attributes will work on halberds
+- All uncommon sword attributes will work on halberds
+- All rare/epic/legendary/mythic sword attributes will work on halberds
+- Etc.
+
+This is by design - it's a transparent extension system.
+
+## Datapack Priority
+
+If you're using multiple datapacks:
+- Mappings from all datapacks are loaded
+- Multiple mappings to the same base verifier are merged
+- Load order doesn't matter
+
+## Debugging
+
+If your mappings aren't working:
+1. Check the server log for "Loaded verifier mapping" messages
+2. Verify your JSON syntax is correct
+3. Ensure the base verifier matches exactly what's in the attribute files
+4. For item IDs, use the full `namespace:item_name` format
+5. For tags, include the namespace (e.g., `c:swords`, not just `swords`)
+
+## Performance
+
+Verifier mappings have minimal performance impact:
+- Loaded once on server start/reload
+- Checked only when items are crafted/looted/spawned
+- Uses efficient lookup structures
+
+## Compatibility
+
+This system is:
+- ✅ Compatible with all existing attribute files
+- ✅ Compatible with other mods' datapacks
+- ✅ Compatible with resource pack reloads (`/reload`)
+- ✅ Backward compatible (works without any mappings)
+- ✅ Forward compatible (new mods can add their own mappings)

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.20.1+build.10
 loader_version=0.14.21
 
 # Mod Properties
-mod_version = 1.2.0
+mod_version = 1.3.0
 maven_group = elocindev
 archives_base_name = Tierify-FABRIC-1.20.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.20.1+build.10
 loader_version=0.14.21
 
 # Mod Properties
-mod_version = 1.3.0
+mod_version = 1.3.1
 maven_group = elocindev
 archives_base_name = Tierify-FABRIC-1.20.1
 

--- a/src/main/java/draylar/tiered/api/ItemVerifier.java
+++ b/src/main/java/draylar/tiered/api/ItemVerifier.java
@@ -2,10 +2,10 @@ package draylar.tiered.api;
 
 import elocindev.tierify.Tierify;
 import elocindev.tierify.data.VerifierMapping;
+import elocindev.tierify.util.TagParsingHelper;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.Registries;
-import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.util.Identifier;
 
@@ -55,7 +55,7 @@ public class ItemVerifier {
         } 
         // Check tag match
         else if (tag != null) {
-            TagKey<Item> itemTag = TagKey.of(RegistryKeys.ITEM, new Identifier(tag));
+            TagKey<Item> itemTag = TagParsingHelper.createItemTagFromId(tag);
             
             if (itemTag != null) {
                 // Check direct tag membership
@@ -95,7 +95,7 @@ public class ItemVerifier {
                 }
             } else if ("tag".equals(mapped.getType())) {
                 // Check tag membership
-                TagKey<Item> mappedTag = TagKey.of(RegistryKeys.ITEM, new Identifier(mapped.getVerifier()));
+                TagKey<Item> mappedTag = TagParsingHelper.createItemTagFromId(mapped.getVerifier());
                 if (new ItemStack(Registries.ITEM.get(new Identifier(itemID))).isIn(mappedTag)) {
                     return true;
                 }
@@ -110,7 +110,7 @@ public class ItemVerifier {
     }
 
     public TagKey<Item> getTagKey() {
-        return TagKey.of(RegistryKeys.ITEM, new Identifier(tag));
+        return TagParsingHelper.createItemTagFromId(tag);
     }
 
     @Override

--- a/src/main/java/elocindev/tierify/Tierify.java
+++ b/src/main/java/elocindev/tierify/Tierify.java
@@ -68,6 +68,14 @@ public class Tierify implements ModInitializer {
      * data/tiered/reforge_item
      */
     public static final ReforgeDataLoader REFORGE_DATA_LOADER = new ReforgeDataLoader();
+    
+    /**
+     * Verifier Mapping Loader instance which handles loading verifier mapping .json files from "data/modid/verifier_mappings".
+     * <p>
+     * This allows datapacks to extend existing verifiers (like "c:swords") to also match additional tags or item IDs
+     * without modifying the base attribute files.
+     */
+    public static final elocindev.tierify.data.VerifierMappingLoader VERIFIER_MAPPING_LOADER = new elocindev.tierify.data.VerifierMappingLoader();
 
     public static ScreenHandlerType<ReforgeScreenHandler> REFORGE_SCREEN_HANDLER_TYPE;
 
@@ -107,6 +115,7 @@ public class Tierify implements ModInitializer {
         SoundRegistry.registerSounds();
         ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(Tierify.ATTRIBUTE_DATA_LOADER);
         ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(Tierify.REFORGE_DATA_LOADER);
+        ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(Tierify.VERIFIER_MAPPING_LOADER);
 
         REFORGE_SCREEN_HANDLER_TYPE = Registry.register(Registries.SCREEN_HANDLER, "tiered:reforge",
                 new ScreenHandlerType<>((syncId, inventory) -> new ReforgeScreenHandler(syncId, inventory, ScreenHandlerContext.EMPTY), FeatureFlags.VANILLA_FEATURES));

--- a/src/main/java/elocindev/tierify/data/ReforgeDataLoader.java
+++ b/src/main/java/elocindev/tierify/data/ReforgeDataLoader.java
@@ -14,17 +14,28 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 import elocindev.tierify.util.TagParsingHelper;
-import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
+import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 import net.minecraft.item.Item;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.resource.ResourceManager;
+import net.minecraft.resource.ResourceReloader;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.profiler.Profiler;
 
-public class ReforgeDataLoader implements SimpleSynchronousResourceReloadListener {
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+public class ReforgeDataLoader implements IdentifiableResourceReloadListener {
 
     private static final Logger LOGGER = LogManager.getLogger("TieredZ");
 
+    // Maps reforge definitions by their file identifier (e.g., "tiered:wooden_club")
+    private Map<Identifier, ReforgeDefinition> reforgeDefinitions = new HashMap<>();
+    
+    // Legacy maps for backward compatibility
     private List<Identifier> reforgeIdentifiers = new ArrayList<>();
     private Map<Identifier, List<Item>> reforgeBaseMap = new HashMap<>();
     private Map<Identifier, ReforgeBaseData> reforgeBaseDataMap = new HashMap<>();
@@ -49,6 +60,54 @@ public class ReforgeDataLoader implements SimpleSynchronousResourceReloadListene
             return tags;
         }
     }
+    
+    /**
+     * Complete reforge definition including both items and base materials with tag support
+     */
+    public static class ReforgeDefinition {
+        private final List<Identifier> directItems;
+        private final List<TagKey<Item>> itemTags;
+        private final ReforgeBaseData baseData;
+        
+        public ReforgeDefinition(List<Identifier> directItems, List<TagKey<Item>> itemTags, ReforgeBaseData baseData) {
+            this.directItems = directItems;
+            this.itemTags = itemTags;
+            this.baseData = baseData;
+        }
+        
+        public List<Identifier> getDirectItems() {
+            return directItems;
+        }
+        
+        public List<TagKey<Item>> getItemTags() {
+            return itemTags;
+        }
+        
+        public ReforgeBaseData getBaseData() {
+            return baseData;
+        }
+        
+        /**
+         * Check if an item matches this reforge definition (either direct or via tag)
+         */
+        public boolean matchesItem(Item item) {
+            Identifier itemId = Registries.ITEM.getId(item);
+            
+            // Check direct item matches
+            if (directItems.contains(itemId)) {
+                return true;
+            }
+            
+            // Check tag matches
+            for (TagKey<Item> tag : itemTags) {
+                if (item.getRegistryEntry().isIn(tag)) {
+                    return true;
+                }
+            }
+            
+            return false;
+        }
+    }
 
     @Override
     public Identifier getFabricId() {
@@ -56,12 +115,55 @@ public class ReforgeDataLoader implements SimpleSynchronousResourceReloadListene
     }
 
     @Override
-    public void reload(ResourceManager resourceManager) {
+    public Collection<Identifier> getFabricDependencies() {
+        // Depend on tags being loaded first
+        return Collections.singletonList(new Identifier("minecraft", "tags"));
+    }
+
+    @Override
+    public CompletableFuture<Void> reload(ResourceReloader.Synchronizer synchronizer, ResourceManager resourceManager,
+                                          Profiler prepareProfiler, Profiler applyProfiler,
+                                          Executor prepareExecutor, Executor applyExecutor) {
+        return CompletableFuture.runAsync(() -> {
+            prepareProfiler.startTick();
+            prepareProfiler.endTick();
+        }, prepareExecutor).thenCompose(synchronizer::whenPrepared).thenRunAsync(() -> {
+            applyProfiler.startTick();
+            applyProfiler.push("reforge_items");
+            loadReforgeData(resourceManager);
+            applyProfiler.pop();
+            applyProfiler.endTick();
+        }, applyExecutor);
+    }
+
+    private void loadReforgeData(ResourceManager resourceManager) {
+        // Clear existing data
+        reforgeDefinitions.clear();
+        reforgeIdentifiers.clear();
+        reforgeBaseMap.clear();
+        reforgeBaseDataMap.clear();
+
+        // Use arrays for counter to allow modification in lambda
+        final int[] filesProcessed = {0};
+        final int[] filesSkipped = {0};
+        final int[] tagsLoaded = {0};
 
         resourceManager.findResources("reforge_items", id -> id.getPath().endsWith(".json")).forEach((id, resourceRef) -> {
             try {
                 InputStream stream = resourceRef.getInputStream();
                 JsonObject data = JsonParser.parseReader(new InputStreamReader(stream)).getAsJsonObject();
+
+                // Validate required fields exist
+                if (!data.has("base") || !data.get("base").isJsonArray()) {
+                    LOGGER.error("Resource {} is missing required 'base' array field", id.toString());
+                    filesSkipped[0]++;
+                    return;
+                }
+                if (!data.has("items") || !data.get("items").isJsonArray()) {
+                    LOGGER.error("Resource {} is missing required 'items' array field", id.toString());
+                    filesSkipped[0]++;
+                    return;
+                }
 
                 // First, parse the base materials (items or tags)
                 List<Item> baseItems = new ArrayList<Item>();
@@ -70,52 +172,95 @@ public class ReforgeDataLoader implements SimpleSynchronousResourceReloadListene
                 for (int i = 0; i < data.getAsJsonArray("base").size(); i++) {
                     String baseEntry = data.getAsJsonArray("base").get(i).getAsString();
                     
-                    // Check if this is a tag (starts with #)
-                    if (TagParsingHelper.isTagReference(baseEntry)) {
-                        String tagId = TagParsingHelper.extractTagId(baseEntry);
-                        TagKey<Item> tag = TagParsingHelper.createItemTagFromId(tagId);
-                        baseTags.add(tag);
-                        LOGGER.info("Loaded tag-based reforge base: {}", tagId);
-                    } else {
-                        // Handle as direct item ID
-                        Item item = TagParsingHelper.getValidItem(baseEntry);
-                        if (item == null) {
-                            LOGGER.info("Resource {} was not loaded cause {} is not a valid item identifier", id.toString(), baseEntry);
-                            continue;
+                    try {
+                        // Check if this is a tag (starts with #)
+                        if (TagParsingHelper.isTagReference(baseEntry)) {
+                            String tagId = TagParsingHelper.extractTagId(baseEntry);
+                            TagKey<Item> tag = TagParsingHelper.createItemTagFromId(tagId);
+                            baseTags.add(tag);
+                            LOGGER.debug("Loaded tag-based reforge base: {} in {}", tagId, id);
+                            tagsLoaded[0]++;
+                        } else {
+                            // Handle as direct item ID
+                            Item item = TagParsingHelper.getValidItem(baseEntry);
+                            if (item == null) {
+                                LOGGER.debug("Resource {} skipped invalid item identifier in base list: {}", id.toString(), baseEntry);
+                                continue;
+                            }
+                            baseItems.add(item);
                         }
-                        baseItems.add(item);
+                    } catch (Exception e) {
+                        LOGGER.error("Resource {} failed to process base entry '{}': {}", id.toString(), baseEntry, e.getMessage());
+                        continue;
                     }
                 }
                 
-                // Now process the items (which can also be tags)
-                List<Identifier> targetItems = new ArrayList<>();
+                // Now process the items (store both direct items and tags without expansion)
+                List<Identifier> directItems = new ArrayList<>();
+                List<TagKey<Item>> itemTags = new ArrayList<>();
                 
                 for (int u = 0; u < data.getAsJsonArray("items").size(); u++) {
                     String itemEntry = data.getAsJsonArray("items").get(u).getAsString();
                     
-                    // Check if this is a tag (starts with #)
-                    if (TagParsingHelper.isTagReference(itemEntry)) {
-                        String tagId = TagParsingHelper.extractTagId(itemEntry);
-                        TagKey<Item> itemTag = TagParsingHelper.createItemTagFromId(tagId);
-                        
-                        // Expand the tag to all items it contains
-                        List<Identifier> expandedIds = TagParsingHelper.expandItemTagToIds(itemTag);
-                        targetItems.addAll(expandedIds);
-                        LOGGER.info("Expanded tag {} to {} items for reforge", tagId, expandedIds.size());
-                    } else {
-                        // Handle as direct item ID
-                        Item item = TagParsingHelper.getValidItem(itemEntry);
-                        if (item == null) {
-                            LOGGER.info("Resource {} was not loaded cause {} is not a valid item identifier", id.toString(), itemEntry);
-                            continue;
+                    try {
+                        // Check if this is a tag (starts with #)
+                        if (TagParsingHelper.isTagReference(itemEntry)) {
+                            String tagId = TagParsingHelper.extractTagId(itemEntry);
+                            TagKey<Item> itemTag = TagParsingHelper.createItemTagFromId(tagId);
+                            itemTags.add(itemTag);
+                            LOGGER.debug("Loaded tag-based reforge items: {} in {}", tagId, id);
+                            tagsLoaded[0]++;
+                        } else {
+                            // Handle as direct item ID
+                            Item item = TagParsingHelper.getValidItem(itemEntry);
+                            if (item == null) {
+                                LOGGER.debug("Resource {} skipped invalid item identifier in items list: {}", id.toString(), itemEntry);
+                                continue;
+                            }
+                            directItems.add(new Identifier(itemEntry));
                         }
-                        targetItems.add(new Identifier(itemEntry));
+                    } catch (Exception e) {
+                        LOGGER.error("Resource {} failed to process item entry '{}': {}", id.toString(), itemEntry, e.getMessage());
+                        continue;
                     }
                 }
                 
-                // Register all target items with the same base data
+                // Check if we have any valid items to register
+                if (directItems.isEmpty() && itemTags.isEmpty()) {
+                    LOGGER.warn("Resource {} has no valid items after processing. Skipping registration.", id.toString());
+                    filesSkipped[0]++;
+                    return;
+                }
+                
+                // Check if we have any valid base materials
+                if (baseItems.isEmpty() && baseTags.isEmpty()) {
+                    LOGGER.warn("Resource {} has no valid base materials after processing. Skipping registration.", id.toString());
+                    filesSkipped[0]++;
+                    return;
+                }
+                
+                // Create the reforge definition
                 ReforgeBaseData baseData = new ReforgeBaseData(baseItems, baseTags);
-                for (Identifier itemId : targetItems) {
+                ReforgeDefinition definition = new ReforgeDefinition(directItems, itemTags, baseData);
+                reforgeDefinitions.put(id, definition);
+                filesProcessed[0]++;
+                
+                LOGGER.debug("Loaded reforge definition from {}: {} direct items, {} item tags, {} base items, {} base tags", 
+                    id, directItems.size(), itemTags.size(), baseItems.size(), baseTags.size());
+                
+                // Also populate legacy maps for backward compatibility
+                // Expand tags at load time for the legacy system
+                List<Identifier> allItemIds = new ArrayList<>(directItems);
+                for (TagKey<Item> tag : itemTags) {
+                    List<Identifier> expandedIds = TagParsingHelper.expandItemTagToIds(tag);
+                    allItemIds.addAll(expandedIds);
+                    
+                    if (expandedIds.isEmpty()) {
+                        LOGGER.debug("Tag {} expanded to 0 items for legacy system in {}. Tags will still work at runtime.", tag.id(), id.toString());
+                    }
+                }
+                
+                for (Identifier itemId : allItemIds) {
                     reforgeIdentifiers.add(itemId);
                     reforgeBaseMap.put(itemId, baseItems); // Keep for backward compatibility
                     reforgeBaseDataMap.put(itemId, baseData);
@@ -123,8 +268,13 @@ public class ReforgeDataLoader implements SimpleSynchronousResourceReloadListene
                 
             } catch (Exception e) {
                 LOGGER.error("Error occurred while loading resource {}. {}", id.toString(), e.toString());
+                filesSkipped[0]++;
             }
         });
+        
+        // Log summary
+        LOGGER.info("Loaded {} reforge definitions ({} skipped) with {} tags using lazy evaluation", 
+            filesProcessed[0], filesSkipped[0], tagsLoaded[0]);
     }
 
     public List<Item> getReforgeBaseItems(Item item) {
@@ -156,6 +306,30 @@ public class ReforgeDataLoader implements SimpleSynchronousResourceReloadListene
 
     public List<Identifier> getReforgeIdentifiers() {
         return reforgeIdentifiers;
+    }
+    
+    /**
+     * Check if an item can be reforged (matches any reforge definition)
+     */
+    public boolean canReforge(Item item) {
+        for (ReforgeDefinition definition : reforgeDefinitions.values()) {
+            if (definition.matchesItem(item)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    /**
+     * Get reforge definition that matches the given item (null if none)
+     */
+    public ReforgeDefinition getReforgeDefinitionFor(Item item) {
+        for (ReforgeDefinition definition : reforgeDefinitions.values()) {
+            if (definition.matchesItem(item)) {
+                return definition;
+            }
+        }
+        return null;
     }
 
 }

--- a/src/main/java/elocindev/tierify/data/ReforgeDataLoader.java
+++ b/src/main/java/elocindev/tierify/data/ReforgeDataLoader.java
@@ -16,6 +16,8 @@ import com.google.gson.JsonParser;
 import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
 import net.minecraft.item.Item;
 import net.minecraft.registry.Registries;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.TagKey;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
 
@@ -25,6 +27,28 @@ public class ReforgeDataLoader implements SimpleSynchronousResourceReloadListene
 
     private List<Identifier> reforgeIdentifiers = new ArrayList<>();
     private Map<Identifier, List<Item>> reforgeBaseMap = new HashMap<>();
+    private Map<Identifier, ReforgeBaseData> reforgeBaseDataMap = new HashMap<>();
+    
+    /**
+     * Holds both direct item references and tag references for reforge base materials
+     */
+    public static class ReforgeBaseData {
+        private final List<Item> directItems;
+        private final List<TagKey<Item>> tags;
+        
+        public ReforgeBaseData(List<Item> directItems, List<TagKey<Item>> tags) {
+            this.directItems = directItems;
+            this.tags = tags;
+        }
+        
+        public List<Item> getDirectItems() {
+            return directItems;
+        }
+        
+        public List<TagKey<Item>> getTags() {
+            return tags;
+        }
+    }
 
     @Override
     public Identifier getFabricId() {
@@ -41,19 +65,37 @@ public class ReforgeDataLoader implements SimpleSynchronousResourceReloadListene
 
                 for (int u = 0; u < data.getAsJsonArray("items").size(); u++) {
                     List<Item> baseItems = new ArrayList<Item>();
+                    List<TagKey<Item>> baseTags = new ArrayList<TagKey<Item>>();
+                    
                     for (int i = 0; i < data.getAsJsonArray("base").size(); i++) {
-                        if (Registries.ITEM.get(new Identifier(data.getAsJsonArray("base").get(i).getAsString())).toString().equals("air")) {
-                            LOGGER.info("Resource {} was not loaded cause {} is not a valid item identifier", id.toString(), data.getAsJsonArray("base").get(i).getAsString());
-                            continue;
+                        String baseEntry = data.getAsJsonArray("base").get(i).getAsString();
+                        
+                        // Check if this is a tag (starts with #)
+                        if (baseEntry.startsWith("#")) {
+                            String tagId = baseEntry.substring(1); // Remove the # prefix
+                            TagKey<Item> tag = TagKey.of(RegistryKeys.ITEM, new Identifier(tagId));
+                            baseTags.add(tag);
+                            LOGGER.info("Loaded tag-based reforge base: {}", tagId);
+                        } else {
+                            // Handle as direct item ID
+                            Item item = Registries.ITEM.get(new Identifier(baseEntry));
+                            if (item.toString().equals("air")) {
+                                LOGGER.info("Resource {} was not loaded cause {} is not a valid item identifier", id.toString(), baseEntry);
+                                continue;
+                            }
+                            baseItems.add(item);
                         }
-                        baseItems.add(Registries.ITEM.get(new Identifier(data.getAsJsonArray("base").get(i).getAsString())));
                     }
+                    
                     if (Registries.ITEM.get(new Identifier(data.getAsJsonArray("items").get(u).getAsString())).toString().equals("air")) {
                         LOGGER.info("Resource {} was not loaded cause {} is not a valid item identifier", id.toString(), data.getAsJsonArray("items").get(u).getAsString());
                         continue;
                     }
-                    reforgeIdentifiers.add(new Identifier(data.getAsJsonArray("items").get(u).getAsString()));
-                    reforgeBaseMap.put(new Identifier(data.getAsJsonArray("items").get(u).getAsString()), baseItems);
+                    
+                    Identifier itemId = new Identifier(data.getAsJsonArray("items").get(u).getAsString());
+                    reforgeIdentifiers.add(itemId);
+                    reforgeBaseMap.put(itemId, baseItems); // Keep for backward compatibility
+                    reforgeBaseDataMap.put(itemId, new ReforgeBaseData(baseItems, baseTags));
                 }
             } catch (Exception e) {
                 LOGGER.error("Error occurred while loading resource {}. {}", id.toString(), e.toString());
@@ -68,6 +110,16 @@ public class ReforgeDataLoader implements SimpleSynchronousResourceReloadListene
         }
         return list;
     }
+    
+    /**
+     * Get complete reforge base data including both direct items and tags
+     */
+    public ReforgeBaseData getReforgeBaseData(Item item) {
+        if (reforgeBaseDataMap.containsKey(Registries.ITEM.getId(item))) {
+            return reforgeBaseDataMap.get(Registries.ITEM.getId(item));
+        }
+        return new ReforgeBaseData(new ArrayList<>(), new ArrayList<>());
+    }
 
     public void putReforgeBaseItems(Identifier id, List<Item> items) {
         reforgeBaseMap.put(id, items);
@@ -75,6 +127,7 @@ public class ReforgeDataLoader implements SimpleSynchronousResourceReloadListene
 
     public void clearReforgeBaseItems() {
         reforgeBaseMap.clear();
+        reforgeBaseDataMap.clear();
     }
 
     public List<Identifier> getReforgeIdentifiers() {

--- a/src/main/java/elocindev/tierify/data/VerifierMapping.java
+++ b/src/main/java/elocindev/tierify/data/VerifierMapping.java
@@ -1,0 +1,59 @@
+package elocindev.tierify.data;
+
+import java.util.List;
+
+/**
+ * Represents a mapping between a base verifier (tag or item ID) and additional verifiers
+ * that should be treated as equivalent for attribute assignment purposes.
+ * 
+ * This allows datapacks to extend support for modded items without modifying
+ * existing attribute definitions.
+ * 
+ * Example: Map "c:swords" to ["c:halberds", "c:polearms", "spartanweaponry:wooden_halberd"]
+ * so that any attribute checking for "c:swords" will also match halberds and polearms.
+ */
+public class VerifierMapping {
+    
+    private final String baseVerifier;
+    private final String baseVerifierType; // "tag" or "id"
+    private final List<MappedVerifier> mappedVerifiers;
+    
+    public VerifierMapping(String baseVerifier, String baseVerifierType, List<MappedVerifier> mappedVerifiers) {
+        this.baseVerifier = baseVerifier;
+        this.baseVerifierType = baseVerifierType;
+        this.mappedVerifiers = mappedVerifiers;
+    }
+    
+    public String getBaseVerifier() {
+        return baseVerifier;
+    }
+    
+    public String getBaseVerifierType() {
+        return baseVerifierType;
+    }
+    
+    public List<MappedVerifier> getMappedVerifiers() {
+        return mappedVerifiers;
+    }
+    
+    /**
+     * Represents a single verifier that should be treated as equivalent to the base verifier.
+     */
+    public static class MappedVerifier {
+        private final String verifier;
+        private final String type; // "tag" or "id"
+        
+        public MappedVerifier(String verifier, String type) {
+            this.verifier = verifier;
+            this.type = type;
+        }
+        
+        public String getVerifier() {
+            return verifier;
+        }
+        
+        public String getType() {
+            return type;
+        }
+    }
+}

--- a/src/main/java/elocindev/tierify/data/VerifierMappingLoader.java
+++ b/src/main/java/elocindev/tierify/data/VerifierMappingLoader.java
@@ -1,0 +1,126 @@
+package elocindev.tierify.data;
+
+import com.google.common.collect.Maps;
+import com.google.gson.*;
+import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
+import net.minecraft.resource.JsonDataLoader;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.profiler.Profiler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Loads verifier mapping files from data/&lt;namespace&gt;/verifier_mappings/*.json
+ * 
+ * These mappings allow datapacks to extend existing verifiers (like "c:swords")
+ * to also match additional tags or item IDs without modifying the base attribute files.
+ * 
+ * Example JSON format:
+ * {
+ *   "base_verifier": "c:swords",
+ *   "base_verifier_type": "tag",
+ *   "mapped_verifiers": [
+ *     { "verifier": "c:halberds", "type": "tag" },
+ *     { "verifier": "c:polearms", "type": "tag" },
+ *     { "verifier": "spartanweaponry:wooden_halberd", "type": "id" }
+ *   ]
+ * }
+ */
+public class VerifierMappingLoader extends JsonDataLoader implements SimpleSynchronousResourceReloadListener {
+    
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+    private static final String PARSING_ERROR_MESSAGE = "Parsing error loading verifier mapping {}";
+    private static final String LOADED_MESSAGE = "Loaded {} verifier mappings";
+    private static final Logger LOGGER = LogManager.getLogger();
+    
+    // Maps base verifier string (e.g., "c:swords") to its mapping definition
+    private Map<String, VerifierMapping> verifierMappings = new HashMap<>();
+    
+    public VerifierMappingLoader() {
+        super(GSON, "verifier_mappings");
+    }
+    
+    @Override
+    protected void apply(Map<Identifier, JsonElement> loader, ResourceManager manager, Profiler profiler) {
+        Map<String, VerifierMapping> readMappings = Maps.newHashMap();
+        
+        for (Map.Entry<Identifier, JsonElement> entry : loader.entrySet()) {
+            Identifier identifier = entry.getKey();
+            
+            try {
+                JsonObject json = entry.getValue().getAsJsonObject();
+                
+                // Parse base verifier
+                String baseVerifier = json.get("base_verifier").getAsString();
+                String baseVerifierType = json.get("base_verifier_type").getAsString();
+                
+                // Parse mapped verifiers
+                List<VerifierMapping.MappedVerifier> mappedVerifiers = new ArrayList<>();
+                JsonArray mappedArray = json.getAsJsonArray("mapped_verifiers");
+                
+                for (JsonElement element : mappedArray) {
+                    JsonObject mappedObj = element.getAsJsonObject();
+                    String verifier = mappedObj.get("verifier").getAsString();
+                    String type = mappedObj.get("type").getAsString();
+                    
+                    mappedVerifiers.add(new VerifierMapping.MappedVerifier(verifier, type));
+                }
+                
+                VerifierMapping mapping = new VerifierMapping(baseVerifier, baseVerifierType, mappedVerifiers);
+                
+                // Store by base verifier for easy lookup
+                // If multiple mappings exist for the same base, merge them
+                if (readMappings.containsKey(baseVerifier)) {
+                    VerifierMapping existing = readMappings.get(baseVerifier);
+                    List<VerifierMapping.MappedVerifier> combined = new ArrayList<>(existing.getMappedVerifiers());
+                    combined.addAll(mappedVerifiers);
+                    mapping = new VerifierMapping(baseVerifier, baseVerifierType, combined);
+                }
+                
+                readMappings.put(baseVerifier, mapping);
+                
+                LOGGER.info("Loaded verifier mapping: {} -> {} mapped verifiers", 
+                    baseVerifier, mappedVerifiers.size());
+                
+            } catch (IllegalArgumentException | JsonParseException exception) {
+                LOGGER.error(PARSING_ERROR_MESSAGE, identifier, exception);
+            }
+        }
+        
+        verifierMappings = readMappings;
+        LOGGER.info(LOADED_MESSAGE, readMappings.size());
+    }
+    
+    /**
+     * Get all verifier mappings
+     */
+    public Map<String, VerifierMapping> getVerifierMappings() {
+        return verifierMappings;
+    }
+    
+    /**
+     * Get mapped verifiers for a specific base verifier
+     * 
+     * @param baseVerifier The base verifier string (e.g., "c:swords")
+     * @return List of mapped verifiers, or empty list if no mapping exists
+     */
+    public List<VerifierMapping.MappedVerifier> getMappedVerifiers(String baseVerifier) {
+        VerifierMapping mapping = verifierMappings.get(baseVerifier);
+        return mapping != null ? mapping.getMappedVerifiers() : new ArrayList<>();
+    }
+    
+    @Override
+    public Identifier getFabricId() {
+        return new Identifier("tiered", "verifier_mappings");
+    }
+    
+    @Override
+    public void reload(ResourceManager resourceManager) {
+    }
+}

--- a/src/main/java/elocindev/tierify/util/TagParsingHelper.java
+++ b/src/main/java/elocindev/tierify/util/TagParsingHelper.java
@@ -50,6 +50,10 @@ public class TagParsingHelper {
      * @return The TagKey for items
      */
     public static TagKey<Item> createItemTagFromId(String tagId) {
+        // Validate that the tag ID doesn't contain #
+        if (tagId != null && tagId.startsWith("#")) {
+            throw new IllegalArgumentException("Tag ID should not contain # prefix. Use extractTagId() first. Got: " + tagId);
+        }
         return TagKey.of(RegistryKeys.ITEM, new Identifier(tagId));
     }
     
@@ -109,6 +113,10 @@ public class TagParsingHelper {
      * @return The Item, or null if it resolves to air
      */
     public static Item getValidItem(String identifier) {
+        // Validate that the identifier doesn't contain #
+        if (identifier != null && identifier.startsWith("#")) {
+            throw new IllegalArgumentException("Item identifier should not contain # prefix. This is a tag reference, not an item ID: " + identifier);
+        }
         Item item = Registries.ITEM.get(new Identifier(identifier));
         return item.toString().equals("air") ? null : item;
     }

--- a/src/main/java/elocindev/tierify/util/TagParsingHelper.java
+++ b/src/main/java/elocindev/tierify/util/TagParsingHelper.java
@@ -1,0 +1,115 @@
+package elocindev.tierify.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.item.Item;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.TagKey;
+import net.minecraft.util.Identifier;
+
+/**
+ * Helper utility for parsing and handling tag-based item references.
+ * Supports the # prefix convention for tag identifiers.
+ */
+public class TagParsingHelper {
+    
+    /**
+     * Checks if a string represents a tag reference (starts with #)
+     */
+    public static boolean isTagReference(String entry) {
+        return entry != null && entry.startsWith("#");
+    }
+    
+    /**
+     * Extracts the tag ID from a tag reference by removing the # prefix
+     * @param tagReference The tag reference string (e.g., "#c:swords")
+     * @return The tag ID without the # prefix (e.g., "c:swords")
+     */
+    public static String extractTagId(String tagReference) {
+        if (!isTagReference(tagReference)) {
+            throw new IllegalArgumentException("Not a tag reference: " + tagReference);
+        }
+        return tagReference.substring(1);
+    }
+    
+    /**
+     * Creates a TagKey from a tag reference string
+     * @param tagReference The tag reference string (e.g., "#c:swords")
+     * @return The TagKey for items
+     */
+    public static TagKey<Item> createItemTag(String tagReference) {
+        String tagId = extractTagId(tagReference);
+        return TagKey.of(RegistryKeys.ITEM, new Identifier(tagId));
+    }
+    
+    /**
+     * Creates a TagKey from a tag ID (without # prefix)
+     * @param tagId The tag identifier (e.g., "c:swords")
+     * @return The TagKey for items
+     */
+    public static TagKey<Item> createItemTagFromId(String tagId) {
+        return TagKey.of(RegistryKeys.ITEM, new Identifier(tagId));
+    }
+    
+    /**
+     * Expands a tag to all items that are members of that tag
+     * @param tag The TagKey to expand
+     * @return List of all items in the tag
+     */
+    public static List<Item> expandItemTag(TagKey<Item> tag) {
+        List<Item> items = new ArrayList<>();
+        for (Item item : Registries.ITEM) {
+            if (item.getDefaultStack().isIn(tag)) {
+                items.add(item);
+            }
+        }
+        return items;
+    }
+    
+    /**
+     * Expands a tag reference string to all items in that tag
+     * @param tagReference The tag reference string (e.g., "#c:swords")
+     * @return List of all items in the tag
+     */
+    public static List<Item> expandItemTagFromReference(String tagReference) {
+        TagKey<Item> tag = createItemTag(tagReference);
+        return expandItemTag(tag);
+    }
+    
+    /**
+     * Expands a tag to all item identifiers that are members of that tag
+     * @param tag The TagKey to expand
+     * @return List of all item identifiers in the tag
+     */
+    public static List<Identifier> expandItemTagToIds(TagKey<Item> tag) {
+        List<Identifier> ids = new ArrayList<>();
+        for (Item item : Registries.ITEM) {
+            if (item.getDefaultStack().isIn(tag)) {
+                ids.add(Registries.ITEM.getId(item));
+            }
+        }
+        return ids;
+    }
+    
+    /**
+     * Checks if an item identifier is valid (not air)
+     * @param identifier The item identifier string
+     * @return true if valid, false if it resolves to air
+     */
+    public static boolean isValidItemIdentifier(String identifier) {
+        Item item = Registries.ITEM.get(new Identifier(identifier));
+        return !item.toString().equals("air");
+    }
+    
+    /**
+     * Gets an item from an identifier, or null if invalid (air)
+     * @param identifier The item identifier string
+     * @return The Item, or null if it resolves to air
+     */
+    public static Item getValidItem(String identifier) {
+        Item item = Registries.ITEM.get(new Identifier(identifier));
+        return item.toString().equals("air") ? null : item;
+    }
+}

--- a/src/main/resources/data/tiered/reforge_items/bow.json
+++ b/src/main/resources/data/tiered/reforge_items/bow.json
@@ -3,6 +3,7 @@
     "minecraft:bow"
   ],
   "base": [
+    "#c:strings",
     "minecraft:string"
   ]
 }

--- a/src/main/resources/data/tiered/reforge_items/crossbow.json
+++ b/src/main/resources/data/tiered/reforge_items/crossbow.json
@@ -3,6 +3,7 @@
     "minecraft:crossbow"
   ],
   "base": [
+    "#c:ingots/iron",
     "minecraft:iron_ingot"
   ]
 }

--- a/src/main/resources/data/tiered/reforge_items/diamond_tools.json
+++ b/src/main/resources/data/tiered/reforge_items/diamond_tools.json
@@ -1,0 +1,13 @@
+{
+  "items": [
+    "minecraft:diamond_sword",
+    "minecraft:diamond_axe",
+    "minecraft:diamond_pickaxe",
+    "minecraft:diamond_shovel",
+    "minecraft:diamond_hoe"
+  ],
+  "base": [
+    "#c:gems/diamond",
+    "minecraft:diamond"
+  ]
+}

--- a/src/main/resources/data/tiered/reforge_items/fishing_rods.json
+++ b/src/main/resources/data/tiered/reforge_items/fishing_rods.json
@@ -3,6 +3,7 @@
     "minecraft:fishing_rod"
   ],
   "base": [
+    "#c:strings",
     "minecraft:string"
   ]
 }

--- a/src/main/resources/data/tiered/reforge_items/iron_tools.json
+++ b/src/main/resources/data/tiered/reforge_items/iron_tools.json
@@ -1,0 +1,12 @@
+{
+  "items": [
+    "minecraft:iron_sword",
+    "minecraft:iron_axe",
+    "minecraft:iron_pickaxe",
+    "minecraft:iron_shovel",
+    "minecraft:iron_hoe"
+  ],
+  "base": [
+    "#c:ingots/iron"
+  ]
+}

--- a/src/main/resources/data/tiered/reforge_items/trident.json
+++ b/src/main/resources/data/tiered/reforge_items/trident.json
@@ -3,6 +3,7 @@
     "minecraft:trident"
   ],
   "base": [
+    "#c:gems/prismarine",
     "minecraft:prismarine_crystals"
   ]
 }

--- a/src/main/resources/data/tiered/verifier_mappings/example_melee_weapons.json
+++ b/src/main/resources/data/tiered/verifier_mappings/example_melee_weapons.json
@@ -1,0 +1,62 @@
+{
+  "base_verifier": "c:swords",
+  "base_verifier_type": "tag",
+  "mapped_verifiers": [
+    {
+      "verifier": "c:halberds",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:polearms",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:spears",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:lances",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:glaives",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:katanas",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:sabers",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:rapiers",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:daggers",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:longswords",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:greatswords",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:warhammers",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:battleaxes",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:maces",
+      "type": "tag"
+    }
+  ]
+}

--- a/src/main/resources/data/tiered/verifier_mappings/example_ranged_weapons.json
+++ b/src/main/resources/data/tiered/verifier_mappings/example_ranged_weapons.json
@@ -1,0 +1,26 @@
+{
+  "base_verifier": "c:bows",
+  "base_verifier_type": "tag",
+  "mapped_verifiers": [
+    {
+      "verifier": "c:longbows",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:crossbows",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:javelins",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:throwing_knives",
+      "type": "tag"
+    },
+    {
+      "verifier": "c:boomerangs",
+      "type": "tag"
+    }
+  ]
+}

--- a/src/main/resources/data/tiered/verifier_mappings/example_specific_items.json
+++ b/src/main/resources/data/tiered/verifier_mappings/example_specific_items.json
@@ -1,0 +1,14 @@
+{
+  "base_verifier": "c:swords",
+  "base_verifier_type": "tag",
+  "mapped_verifiers": [
+    {
+      "verifier": "example_mod:example_item",
+      "type": "id"
+    },
+    {
+      "verifier": "examplemod:exampleitem",
+      "type": "id"
+    }
+  ]
+}


### PR DESCRIPTION
TLDR add a system to map modded items/tags to existing attributes without having to use a datapack which overrides the whole attributes files and add tag support to the reforge items. 

This pull request introduces significant new features and improvements to Tierify, focusing on enhanced support for modded items, extensibility, and better documentation. The most notable changes are the introduction of a data-driven verifier mappings system, tag support for reforge recipes, and major improvements to validation, logging, and error handling. These updates make it much easier for datapack creators and modders to add compatibility for modded weapons, tools, and armor without modifying core attribute files.

**Key changes include:**

### New Features for Modded Item Support

* **Verifier Mappings System:** Introduced a flexible, data-driven system allowing datapacks to extend item attribute verifiers to new tags or item IDs using JSON files in `data/<namespace>/verifier_mappings/`. This lets modded items (e.g., halberds, spears) inherit attributes from vanilla categories without editing base files. Full documentation is provided in the new `VERIFIER_MAPPINGS.md`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1-R82) [[2]](diffhunk://#diff-932da67dab92b4c509ef519da29dbd2e1e0bf2117b174ee60d7adfc3b8e1b46cR1-R202) [[3]](diffhunk://#diff-b7c5962ec47d5bf3ef9a36ff74be99834fc96b25cf133cd11d2899ad758a474fR4-R13) [[4]](diffhunk://#diff-b7c5962ec47d5bf3ef9a36ff74be99834fc96b25cf133cd11d2899ad758a474fR40-R66) [[5]](diffhunk://#diff-b7c5962ec47d5bf3ef9a36ff74be99834fc96b25cf133cd11d2899ad758a474fR75-R113) [[6]](diffhunk://#diff-1c007ab1386a8a95a452fb7cc4672012b89ee5b48b09be33ced85cfe2e3da40cR72-R79) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R31-R74)

* **Tag Support in Reforge Items:** Both `items` and `base` fields in reforge recipes now support tag references using the `#` prefix, enabling broad and automatic support for modded items and reducing duplication. Documentation and usage examples are included in `README.md`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1-R82) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R179-R181) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R193-R270)

### Technical Improvements & Refactoring

* **Centralized Tag Parsing and Validation:** Added a `TagParsingHelper` utility class to standardize tag handling, reducing code duplication and improving maintainability across data loaders and verifiers.

* **Lazy Tag Loading and Improved Reliability:** Tags in reforge recipes are now stored as references and expanded at runtime, ensuring modded tags work immediately and improving compatibility/reliability. Added dependency declarations and switched resource reload listeners for correct tag loading order.

### Usability, Logging, and Documentation

* **Improved Logging and Error Handling:** Logging output is cleaner, with granular details moved to debug level and summary statistics at info level. Validation and error handling prevent malformed entries from breaking data loading.

* **Expanded and Updated Documentation:** `README.md` and new markdown files provide clear quick-start guides, troubleshooting, and reference material for both verifier mappings and tag-based reforge support. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R31-R74) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R179-R181) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R193-R270) [[4]](diffhunk://#diff-932da67dab92b4c509ef519da29dbd2e1e0bf2117b174ee60d7adfc3b8e1b46cR1-R202)

### Versioning

* **Version Bump:** Updated mod version to `1.3.1` to reflect these major new features and improvements.